### PR TITLE
Sellatron department selection method is now a config option.

### DIFF
--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -16,6 +16,7 @@
 	var/wl_security = FALSE			//Whitelist Security?
 	var/wl_silicons = FALSE			//Whitelist silicons?
 	var/wl_admins_too = FALSE		//Do admins go through whitelist checks?
+	var/sellatron_auto = FALSE	//Do we want the Sellatron to be manual?
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")		//We don't want to add shit to the main config when we update this (merge conflicts)
@@ -53,6 +54,8 @@
 				config.wl_silicons = TRUE
 			if("admins_restricted_by_whitelist")
 				config.wl_admins_too = TRUE
+			if("sellatron_auto_department")
+				config.sellatron_auto = TRUE
 
 
 	config.eclipse_config_loaded = TRUE		//config is loaded

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -16,7 +16,7 @@
 	var/wl_security = FALSE			//Whitelist Security?
 	var/wl_silicons = FALSE			//Whitelist silicons?
 	var/wl_admins_too = FALSE		//Do admins go through whitelist checks?
-	var/sellatron_auto = FALSE	//Do we want the Sellatron to be manual?
+	var/sellatron_auto = FALSE		//Do we want the Sellatron to be manual?
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")		//We don't want to add shit to the main config when we update this (merge conflicts)

--- a/code/game/machinery/sellingmachines.dm
+++ b/code/game/machinery/sellingmachines.dm
@@ -20,6 +20,7 @@
 	var/obj/item/stored_item				// What's in it, right now.
 
 	var/allow_select_department = 0			// If this is set to 0, it will pull your department from your ID instead.
+	// ECLIPSE NOTE: This is overwritten by the active relevant config option in sellingmachines_eclipse.dm.
 
 	var/department_charged					// If we want this to charge a certain department. If left null, it will charge from city account.
 

--- a/code/game/machinery/sellingmachines_eclipse.dm
+++ b/code/game/machinery/sellingmachines_eclipse.dm
@@ -8,7 +8,7 @@
 	
 	//Config should be loaded now that the while-loop is broken
 	
-	allow_select_department = !sellatron_auto
+	allow_select_department = !config.sellatron_auto
 	//I know that looks ass-backwards, but if it's NOT set to allow you to
 	//choose your department, it will automatically pick it based on your ID.
 	

--- a/code/game/machinery/sellingmachines_eclipse.dm
+++ b/code/game/machinery/sellingmachines_eclipse.dm
@@ -1,0 +1,16 @@
+// Eclipse-specific behaviour for Sellatrons.
+
+/obj/machinery/selling_machine/Initialize()
+// Wait for config to be loaded first, so we know if we want the Sellatron to
+// charge to the ID department by default, or if we need to select it manually.
+	while(!config.eclipse_config_loaded)
+		sleep(5)
+	
+	//Config should be loaded now that the while-loop is broken
+	
+	allow_select_department = !sellatron_auto
+	//I know that looks ass-backwards, but if it's NOT set to allow you to
+	//choose your department, it will automatically pick it based on your ID.
+	
+	//say shit so we know it worked
+	log_debug("Sellatron at [x], [y], [z]: department selection set to [allow_select_department ? "manual" : "automatic"]")

--- a/code/game/machinery/sellingmachines_eclipse.dm
+++ b/code/game/machinery/sellingmachines_eclipse.dm
@@ -1,6 +1,7 @@
 // Eclipse-specific behaviour for Sellatrons.
 
-/obj/machinery/selling_machine/Initialize()
+/obj/machinery/selling_machine/initialize()
+
 // Wait for config to be loaded first, so we know if we want the Sellatron to
 // charge to the ID department by default, or if we need to select it manually.
 	while(!config.eclipse_config_loaded)
@@ -11,6 +12,9 @@
 	allow_select_department = !config.sellatron_auto
 	//I know that looks ass-backwards, but if it's NOT set to allow you to
 	//choose your department, it will automatically pick it based on your ID.
+	//(the left side of the assignment is the 'is it on manual mode' variable)
 	
 	//say shit so we know it worked
-	log_debug("Sellatron at [x], [y], [z]: department selection set to [allow_select_department ? "manual" : "automatic"]")
+	log_debug("Sellatron at ([x], [y], [z]): department selection set to [allow_select_department ? "manual" : "automatic"]")
+	
+	return INITIALIZE_HINT_NORMAL		//alles gut

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -31,3 +31,14 @@ WHITELIST_HEADS
 ## Should silicons be whitelisted? This will not affect pAIs, only AI and borgs.
 ## Uncomment to whitelist.
 #WHITELIST_SILICONS
+
+#########
+# MISCELLANY
+#########
+
+## SELLATRON AUTOMATIC DEPARTMENT SELECTION
+## Should the Sellatron automatically read the department from the user's ID?
+## This can cause issues when a person with a Nanotrasen ID tries to sell things
+## but can prevent an issue where the Sellatron is set to the wrong department.
+## Uncomment to enable ID-based department selection.
+#SELLATRON_AUTO_DEPARTMENT

--- a/polaris.dme
+++ b/polaris.dme
@@ -725,6 +725,7 @@
 #include "code\game\machinery\robot_fabricator.dm"
 #include "code\game\machinery\seed_extractor.dm"
 #include "code\game\machinery\sellingmachines.dm"
+#include "code\game\machinery\sellingmachines_eclipse.dm"
 #include "code\game\machinery\Sleeper.dm"
 #include "code\game\machinery\spaceheater.dm"
 #include "code\game\machinery\status_display.dm"


### PR DESCRIPTION
:cl: EvilJackCarver
bugfix: Sellatron department selection is now a config option.
/:cl:

# ⚠️ CONFIG (ECLIPSE) HAS BEEN UPDATED.

## Added config options
* SELLATRON_AUTO_DEPARTMENT
  * Should the Sellatron try to ascertain which department to put the funds into by the user's ID card?
    * Behaviour if Commented: Players will need to manually select which department they want to put funds into when they sell things.
    * Behaviour if Uncommented: Sellatron will put funds into the department specified by the players' ID card.
  * Default: Commented